### PR TITLE
Version was not patched in build workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build HTML
         shell: pwsh
-        run: .\Build.ps1 -BuildHtml
+        run: .\Build.ps1 -SetAssemblyVersion -BuildHtml
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
The `%VERSION%` placeholder was not patched while running the build workflow