### PR TITLE
Enhancement/5 - Renamed clone to entryPrototype

### DIFF
--- a/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/components/ConfigEditor/CollectionEditor.tsx
+++ b/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/components/ConfigEditor/CollectionEditor.tsx
@@ -49,18 +49,18 @@ export default class CollectionEditor extends CollapsibleEntryEditorBase<Collect
 
     public addEntry(): void {
         const prototype = this.props.Entry.Prototypes.find((proto: Entry) => proto.DisplayName === this.state.SelectedEntry);
-        const entryClone = Entry.cloneFromPrototype(prototype, this.props.Entry);
+        const entryPrototype = Entry.entryFromPrototype(prototype, this.props.Entry);
 
         let counter: number = 0;
-        let entryName: string = entryClone.DisplayName;
+        let entryName: string = entryPrototype.DisplayName;
 
         while (this.props.Entry.SubEntries.find((subEntry: Entry) => subEntry.DisplayName === entryName) !== undefined) {
             ++counter;
-            entryName = entryClone.DisplayName + " " + counter.toString();
+            entryName = entryPrototype.DisplayName + " " + counter.toString();
         }
 
-        entryClone.DisplayName = entryName;
-        this.props.Entry.SubEntries.push(entryClone);
+        entryPrototype.DisplayName = entryName;
+        this.props.Entry.SubEntries.push(entryPrototype);
 
         this.forceUpdate();
     }

--- a/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/components/ConfigEditor/ConfigEditor.tsx
+++ b/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/components/ConfigEditor/ConfigEditor.tsx
@@ -97,17 +97,17 @@ export default class ConfigEditor extends React.Component<ConfigEditorPropModel,
                 return;
         }
 
-        const clone = Entry.cloneFromPrototype(prototype, this.props.ParentEntry.Parent);
-        clone.Prototypes = JSON.parse(JSON.stringify(this.props.ParentEntry.Prototypes));
-        clone.DisplayName = this.props.ParentEntry.DisplayName;
-        clone.Identifier = this.props.ParentEntry.Identifier;
+        const entryPrototype = Entry.entryFromPrototype(prototype, this.props.ParentEntry.Parent);
+        entryPrototype.Prototypes = JSON.parse(JSON.stringify(this.props.ParentEntry.Prototypes));
+        entryPrototype.DisplayName = this.props.ParentEntry.DisplayName;
+        entryPrototype.Identifier = this.props.ParentEntry.Identifier;
 
         const subEntries: Entry[] = this.props.ParentEntry.Parent.SubEntries;
 
         const idx = subEntries.indexOf(this.props.ParentEntry);
         if (idx !== -1) {
-            subEntries[idx] = clone;
-            this.setState({SelectedEntryType: clone.Value.Current});
+            subEntries[idx] = entryPrototype;
+            this.setState({SelectedEntryType: entryPrototype.Value.Current});
             this.props.navigateToEntry(this.props.ParentEntry);
         }
     }

--- a/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
+++ b/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
@@ -58,13 +58,7 @@ export default class Entry {
      * @deprecated It should be replaced by entryFromPrototype after the major release
      */
     public static cloneFromPrototype(prototype: Entry, parent: Entry): Entry {
-        const entryPrototype = JSON.parse(JSON.stringify(prototype));
-
-        Config.patchParent(entryPrototype, parent);
-
-        entryPrototype.Identifier = "CREATED";
-        Entry.generateUniqueIdentifiers(entryPrototype);
-        return entryPrototype;
+        return Entry.entryFromPrototype(prototype, parent);
     }
 
     public static entryFromPrototype(prototype: Entry, parent: Entry): Entry {

--- a/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
+++ b/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
@@ -54,13 +54,13 @@ export default class Entry {
         });
     }
 
-    public static cloneFromPrototype(prototype: Entry, parent: Entry): Entry {
-        const entryClone = JSON.parse(JSON.stringify(prototype));
+    public static entryFromPrototype(prototype: Entry, parent: Entry): Entry {
+        const entryPrototype = JSON.parse(JSON.stringify(prototype));
 
-        Config.patchParent(entryClone, parent);
+        Config.patchParent(entryPrototype, parent);
 
-        entryClone.Identifier = "CREATED";
-        Entry.generateUniqueIdentifiers(entryClone);
-        return entryClone;
+        entryPrototype.Identifier = "CREATED";
+        Entry.generateUniqueIdentifiers(entryPrototype);
+        return entryPrototype;
     }
 }

--- a/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
+++ b/src/Moryx.Runtime.Maintenance.Web.UI/src/modules/models/Entry.ts
@@ -54,6 +54,19 @@ export default class Entry {
         });
     }
 
+    /**
+     * @deprecated It should be replaced by entryFromPrototype after the major release
+     */
+    public static cloneFromPrototype(prototype: Entry, parent: Entry): Entry {
+        const entryPrototype = JSON.parse(JSON.stringify(prototype));
+
+        Config.patchParent(entryPrototype, parent);
+
+        entryPrototype.Identifier = "CREATED";
+        Entry.generateUniqueIdentifiers(entryPrototype);
+        return entryPrototype;
+    }
+
     public static entryFromPrototype(prototype: Entry, parent: Entry): Entry {
         const entryPrototype = JSON.parse(JSON.stringify(prototype));
 


### PR DESCRIPTION
Renamed clone to entryPrototype as prototype was already in use but now naming is more consistent

